### PR TITLE
decimal: add support for the decomposer interface

### DIFF
--- a/decimal_test.go
+++ b/decimal_test.go
@@ -192,3 +192,14 @@ func BenchmarkDecimal_Multiplication(b *testing.B) {
 		x.Multiply(y)
 	}
 }
+
+func TestAllDecimalPrint(t *testing.T) {
+	const s = "0.12345600"
+	d, err := FromString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ds := d.String(); ds != s {
+		t.Fatalf("got %q want %q", ds, s)
+	}
+}

--- a/decomposer.go
+++ b/decomposer.go
@@ -1,0 +1,110 @@
+package decimal
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// decomposer returns the internal decimal state into parts.
+// If the provided// Decimal composes or decomposes a decimal value to and from individual parts.
+// There are four separate parts: a boolean negative flag, a form byte with three possible states
+// (finite=0, infinite=1, NaN=2),  a base-2 big-endian integer
+// coefficient (also known as a significand) as a []byte, and an int32 exponent.
+// These are composed into a final value as "decimal = (neg) (form=finite) coefficient * 10 ^ exponent".
+// A zero length coefficient is a zero value.
+// If the form is not finite the coefficient and scale should be ignored.
+// The negative parameter may be set to true for any form, although implementations are not required
+// to respect the negative parameter in the non-finite form.
+//
+// Implementations may choose to signal a negative zero or negative NaN, but implementations
+// that do not support these may also ignore the negative zero or negative NaN without error.
+// If an implementation does not support Infinity it may be converted into a NaN without error.
+// If a value is set that is larger then what is supported by an implementation is attempted to
+// be set, an error must be returned.
+// Implementations must return an error if a NaN or Infinity is attempted to be set while neither
+// are supported.
+type decomposer interface {
+	// Decompose returns the internal decimal state into parts.
+	// If the provided buf has sufficient capacity, buf may be returned as the coefficient with
+	// the value set and length set as appropriate.
+	Decompose(buf []byte) (form byte, negative bool, coefficient []byte, exponent int32)
+
+	// Compose sets the internal decimal value from parts. If the value cannot be
+	// represented then an error should be returned.
+	Compose(form byte, negative bool, coefficient []byte, exponent int32) error
+}
+
+// Decompose returns the internal decimal state into parts.
+// If the provided buf has sufficient capacity, buf may be returned as the coefficient with
+// the value set and length set as appropriate.
+func (d Decimal) Decompose(buf []byte) (form byte, negative bool, coefficient []byte, exponent int32) {
+	if d == 0 {
+		return
+	}
+	if cap(buf) >= 8 {
+		coefficient = buf[:8]
+	} else {
+		coefficient = make([]byte, 8)
+	}
+	binary.BigEndian.PutUint64(coefficient, uint64(d))
+	exponent = -8
+	return
+}
+
+// Compose sets the internal decimal value from parts. If the value cannot be
+// represented then an error should be returned.
+func (d *Decimal) Compose(form byte, negative bool, coefficient []byte, exponent int32) (err error) {
+	if d == nil {
+		return errors.New("Fixed must not be nil")
+	}
+	switch form {
+	default:
+		return errors.New("invalid form")
+	case 0:
+		// Finite form, see below.
+	case 1:
+		return errors.New("infinite form unsupported")
+	case 2:
+		return errors.New("NaN form unsupported")
+	}
+	// Finite form.
+	if negative {
+		return errors.New("negative unsupported")
+	}
+
+	var c uint64
+	maxi := len(coefficient) - 1
+	for i := range coefficient {
+		v := coefficient[maxi-i]
+		if i < 8 {
+			c |= uint64(v) << (i * 8)
+		} else if v != 0 {
+			return fmt.Errorf("coefficent too large")
+		}
+	}
+
+	dividePower := int(exponent) + 8
+	ct := dividePower
+	if ct < 0 {
+		ct = -ct
+	}
+	var power uint64 = 1
+	for i := 0; i < ct; i++ {
+		power *= 10
+	}
+	checkC := c
+	if dividePower < 0 {
+		c = c / power
+		if c*power != checkC {
+			return fmt.Errorf("unable to store decimal, greater then 7 decimals")
+		}
+	} else if dividePower > 0 {
+		c = c * power
+		if c/power != checkC {
+			return fmt.Errorf("enable to store decimal, too large")
+		}
+	}
+	*d = Decimal(c)
+	return nil
+}

--- a/decomposer_test.go
+++ b/decomposer_test.go
@@ -1,0 +1,80 @@
+package decimal
+
+import (
+	"testing"
+)
+
+func TestDecomposerRoundTrip(t *testing.T) {
+	list := []struct {
+		N string // Name.
+		S string // String value.
+		E bool   // Expect an error.
+	}{
+		{N: "Zero", S: "0.00000000"},
+		{N: "Normal-1", S: "123.456"},
+	}
+	for _, item := range list {
+		t.Run(item.N, func(t *testing.T) {
+			d, err := FromString(item.S)
+			if err != nil {
+				t.Fatalf("failed to parse number: %v", err)
+			}
+			var set0 Decimal
+			set := &set0
+			err = set.Compose(d.Decompose(nil))
+			if err == nil && item.E {
+				t.Fatal("expected error, got <nil>")
+			}
+			if err != nil && !item.E {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if *set != d {
+				t.Fatalf("values incorrect, got %v want %v (%s)", set, d, item.S)
+			}
+		})
+	}
+}
+
+func TestDecomposerCompose(t *testing.T) {
+	list := []struct {
+		N string // Name.
+		S string // String value.
+
+		Form byte // Form
+		Neg  bool
+		Coef []byte // Coefficent
+		Exp  int32
+
+		Err bool // Expect an error.
+	}{
+		{N: "Zero", S: "0.00000000", Coef: nil, Exp: 0},
+		{N: "Normal-1", S: "123.45600000", Coef: []byte{0x01, 0xE2, 0x40}, Exp: -3},
+		{N: "Neg-1", S: "-123.45600000", Neg: true, Coef: []byte{0x01, 0xE2, 0x40}, Exp: -3, Err: true},
+		{N: "PosExp-1", S: "123456000.00000000", Coef: []byte{0x01, 0xE2, 0x40}, Exp: 3},
+		{N: "PosExp-2", S: "-123456000.00000000", Neg: true, Coef: []byte{0x01, 0xE2, 0x40}, Exp: 3, Err: true},
+		{N: "AllDec-1", S: "0.12345600", Coef: []byte{0x01, 0xE2, 0x40}, Exp: -6},
+		{N: "AllDec-2", S: "-0.123456", Neg: true, Coef: []byte{0x01, 0xE2, 0x40}, Exp: -6, Err: true},
+		{N: "TooSmall-1", S: "0.0000123456", Neg: true, Coef: []byte{0x01, 0xE2, 0x40}, Exp: -8, Err: true},
+		{N: "NaN-1", S: "NaN", Form: 2, Err: true},
+	}
+
+	for _, item := range list {
+		t.Run(item.N, func(t *testing.T) {
+			var d0 Decimal
+			d := &d0
+			err := d.Compose(item.Form, item.Neg, item.Coef, item.Exp)
+			if err != nil && !item.Err {
+				t.Fatalf("unexpected error, got %v", err)
+			}
+			if item.Err {
+				if err == nil {
+					t.Fatal("expected error, got <nil>")
+				}
+				return
+			}
+			if s := d.String(); s != item.S {
+				t.Fatalf("unexpected value, got %q want %q", s, item.S)
+			}
+		})
+	}
+}


### PR DESCRIPTION
While I beleive this code is accurate, tests currently don't pass
due to what I beleive is a bug in Decimal.String when printing
all decimal values. A specific test for this failure was
added. Once the strings are printing correctly, tests should pass.

For golang/go#30870